### PR TITLE
Take conflicting items into account during evaluation

### DIFF
--- a/cmd/evaluator/main.go
+++ b/cmd/evaluator/main.go
@@ -53,11 +53,17 @@ func main() {
 	log.Info().Msgf("Evaluating %d weapons", len(weaponIds))
 
 	dataService := evaluator.CreateDataService(dbClient.Conn)
-	weaponPossibilities := createWeaponPossibilities(weaponIds, dataService)
-	log.Info().Msgf("Generated %d weapon possibility trees.", len(weaponPossibilities))
+	candidateTree := createWeaponCandidateTree(weaponIds, dataService)
+	log.Info().Msgf("Generated %d weapon possibility trees.", len(candidateTree))
+
+	for i := 0; i < len(candidateTree); i++ {
+		if len(candidateTree[i].Item.ConflictingItems) > 0 {
+			log.Info().Msgf("conflicted item at index %d", i)
+		}
+	}
 
 	log.Info().Msg("Creating evaluation tasks.")
-	tasks := createEvaluationTasks(weaponPossibilities, []string{"recoil", "ergonomics"})
+	tasks := createEvaluationTasks(candidateTree, []string{"recoil", "ergonomics"})
 	log.Info().Msgf("Scheduled %d evaluation tasks.", len(tasks))
 
 	log.Info().Msg("Processing evaluation tasks.")

--- a/cmd/evaluator/main.go
+++ b/cmd/evaluator/main.go
@@ -53,14 +53,8 @@ func main() {
 	log.Info().Msgf("Evaluating %d weapons", len(weaponIds))
 
 	dataService := evaluator.CreateDataService(dbClient.Conn)
-	candidateTree := createWeaponCandidateTree(weaponIds, dataService)
-	log.Info().Msgf("Generated %d weapon possibility trees.", len(candidateTree))
-
-	for i := 0; i < len(candidateTree); i++ {
-		if len(candidateTree[i].Item.ConflictingItems) > 0 {
-			log.Info().Msgf("conflicted item at index %d", i)
-		}
-	}
+	candidateTree := createWeaponCandidateTrees(weaponIds, dataService)
+	log.Info().Msgf("Generated %d weapon candidate trees.", len(candidateTree))
 
 	log.Info().Msg("Creating evaluation tasks.")
 	tasks := createEvaluationTasks(candidateTree, []string{"recoil", "ergonomics"})

--- a/cmd/evaluator/tasks.go
+++ b/cmd/evaluator/tasks.go
@@ -108,7 +108,7 @@ func createEvaluationTasks(weaponPossibilities []WeaponPossibilityResult, evalua
 	return tasks
 }
 
-func createWeaponPossibilities(weaponIds []string, dataProvider evaluator.TreeDataProvider) []WeaponPossibilityResult {
+func createWeaponCandidateTree(weaponIds []string, dataProvider evaluator.TreeDataProvider) []WeaponPossibilityResult {
 	results := make([]WeaponPossibilityResult, 0)
 
 	for i := 0; i < len(weaponIds); i++ {

--- a/go.mod
+++ b/go.mod
@@ -4,11 +4,14 @@ go 1.22
 
 require (
 	github.com/Khan/genqlient v0.7.0
-	github.com/jackc/pgx/v4 v4.18.3
+	//github.com/jackc/pgx/v4 v4.18.3
 	github.com/labstack/echo/v4 v4.12.0
+	github.com/lib/pq v1.10.2
 	github.com/pressly/goose/v3 v3.21.1
 	github.com/stretchr/testify v1.9.0
 )
+
+require github.com/jackc/pgx/v4 v4.12.1-0.20210724153913-640aa07df17c
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -70,9 +70,8 @@ github.com/jackc/pgtype v1.14.0/go.mod h1:LUMuVrfsFfdKGLw+AFFVv6KtHOFMwRgDDzBt76
 github.com/jackc/pgx/v4 v4.0.0-20190420224344-cc3461e65d96/go.mod h1:mdxmSJJuR08CZQyj1PVQBHy9XOp5p8/SHH6a0psbY9Y=
 github.com/jackc/pgx/v4 v4.0.0-20190421002000-1b8f0016e912/go.mod h1:no/Y67Jkk/9WuGR0JG/JseM9irFbnEPbuWV2EELPNuM=
 github.com/jackc/pgx/v4 v4.0.0-pre1.0.20190824185557-6972a5742186/go.mod h1:X+GQnOEnf1dqHGpw7JmHqHc1NxDoalibchSk9/RWuDc=
+github.com/jackc/pgx/v4 v4.12.1-0.20210724153913-640aa07df17c h1:Dznn52SgVIVst9UyOT9brctYUgxs+CvVfPaC3jKrA50=
 github.com/jackc/pgx/v4 v4.12.1-0.20210724153913-640aa07df17c/go.mod h1:1QD0+tgSXP7iUjYm9C1NxKhny7lq6ee99u/z+IHFcgs=
-github.com/jackc/pgx/v4 v4.18.3 h1:dE2/TrEsGX3RBprb3qryqSV9Y60iZN1C6i8IrmW9/BA=
-github.com/jackc/pgx/v4 v4.18.3/go.mod h1:Ey4Oru5tH5sB6tV7hDmfWFahwF15Eb7DNXlRKx2CkVw=
 github.com/jackc/puddle v0.0.0-20190413234325-e4ced69a3a2b/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
 github.com/jackc/puddle v0.0.0-20190608224051-11cab39313c9/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
 github.com/jackc/puddle v1.1.3/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -4,9 +4,8 @@ import (
 	"database/sql"
 	"fmt"
 
+	_ "github.com/lib/pq"
 	"github.com/rs/zerolog/log"
-
-	_ "github.com/jackc/pgx/v4/stdlib"
 )
 
 type DatabaseConfig struct {
@@ -33,7 +32,7 @@ func NewDatabase(config Config) (*Database, error) {
 	connStrTemplate := "postgresql://%s:%s@%s:%s/%s?sslmode=disable"
 	connStr := fmt.Sprintf(connStrTemplate, config.User, config.Password, config.Host, config.Port, config.Name)
 	log.Debug().Msgf("Connecting to database: %s:%s", config.Host, config.Port)
-	db, err := sql.Open("pgx", connStr)
+	db, err := sql.Open("postgres", connStr)
 	if err != nil {
 		return nil, fmt.Errorf("failed to connect to database: %w", err)
 	}

--- a/internal/env/env.go
+++ b/internal/env/env.go
@@ -32,7 +32,7 @@ var (
 func getInt(key string, def int) int {
 	value, err := strconv.Atoi(os.Getenv(key))
 	if err != nil {
-		log.Error().Err(err).Msgf("Failed to convert env var %s to integer", key)
+		log.Warn().Err(err).Msgf("Failed to convert env var %s to integer", key)
 		return def
 	}
 	return value

--- a/internal/evaluator/evaluator_test.go
+++ b/internal/evaluator/evaluator_test.go
@@ -124,7 +124,8 @@ func TestFindBestRecoilTree(t *testing.T) {
 	}
 
 	evaluator := CreateEvaluator(dataProvider)
-	build, err := evaluator.evaluate(weapon, "recoil", constraints)
+	candidates := []string{"weapon1", "item1", "item2", "item3", "child-item1"}
+	build, err := evaluator.evaluate(weapon, "recoil", constraints, candidates)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -172,7 +173,7 @@ func TestFindBestRecoilTree(t *testing.T) {
 
 func TestFindBestErgoTree(t *testing.T) {
 	rootWeaponTree := &WeaponTree{}
-	weapon := ConstructItem("test-item", "Test Item", rootWeaponTree)
+	weapon := ConstructItem("weapon1", "Test Item", rootWeaponTree)
 	weapon.RecoilModifier = -10
 	weapon.ErgonomicsModifier = 10
 
@@ -213,7 +214,8 @@ func TestFindBestErgoTree(t *testing.T) {
 	}
 	evaluator := CreateEvaluator(dataProvider)
 
-	build, err := evaluator.evaluate(weapon, "recoil", constraints)
+	candidates := []string{"weapon1", "item1", "item2", "item3", "child-item1"}
+	build, err := evaluator.evaluate(weapon, "recoil", constraints, candidates)
 
 	if err != nil {
 		t.Fatal(err)

--- a/internal/evaluator/item.go
+++ b/internal/evaluator/item.go
@@ -11,6 +11,7 @@ type Item struct {
 	ErgonomicsModifier int         `json:"ergonomics_modifier" bson:"ergonomics_modifier"`
 	Slots              []*ItemSlot `json:"slots" bson:"slots"`
 	Type               string      `json:"type" bson:"type"`
+	ConflictingItems   []string    `json:"conflicting_items" bson:"conflicting_items"`
 	parentSlot         *ItemSlot
 	RootItem           *Item
 	RootWeaponTree     *WeaponTree
@@ -18,10 +19,11 @@ type Item struct {
 
 func ConstructItem(id string, name string, rootWeaponTree *WeaponTree) *Item {
 	return &Item{
-		ID:             id,
-		Name:           name,
-		Slots:          make([]*ItemSlot, 0),
-		RootWeaponTree: rootWeaponTree,
+		ID:               id,
+		Name:             name,
+		Slots:            make([]*ItemSlot, 0),
+		RootWeaponTree:   rootWeaponTree,
+		ConflictingItems: make([]string, 0),
 	}
 }
 

--- a/internal/evaluator/item_slot.go
+++ b/internal/evaluator/item_slot.go
@@ -113,7 +113,10 @@ func (slot *ItemSlot) PopulateAllowedItems() error {
 			// must add first - add child maintains the parent relationship
 			slot.AddChildItem(item)
 
-			slot.RootWeaponTree.AddItemConflicts(item.ID, item.ConflictingItems)
+			if len(item.ConflictingItems) > 0 {
+				slot.RootWeaponTree.AddItemConflicts(item.ID, item.ConflictingItems)
+			}
+			slot.RootWeaponTree.AddCandidateItem(item.ID)
 
 			err := item.PopulateSlots()
 			if err != nil {

--- a/internal/evaluator/item_slot.go
+++ b/internal/evaluator/item_slot.go
@@ -107,10 +107,14 @@ func (slot *ItemSlot) PopulateAllowedItems() error {
 		item.RecoilModifier = modProperties.RecoilModifier
 		item.ErgonomicsModifier = modProperties.ErgonomicsModifier
 		item.Type = "weapon_mod"
+		item.ConflictingItems = modProperties.ConflictingItems
 
 		if slot.IsItemValidChild(item) {
 			// must add first - add child maintains the parent relationship
 			slot.AddChildItem(item)
+
+			slot.RootWeaponTree.AddItemConflicts(item.ID, item.ConflictingItems)
+
 			err := item.PopulateSlots()
 			if err != nil {
 				log.Error().Err(err).Msgf("Failed to populate slot %s with item: %s", slot.ID, item.ID)

--- a/internal/evaluator/weapon_tree.go
+++ b/internal/evaluator/weapon_tree.go
@@ -89,7 +89,6 @@ func GenerateNonConflictingCandidateSets(candidates map[string]bool, conflicts m
 		bans := map[string]bool{}
 		for candidateID, _ := range candidates {
 			if _, ok := resolved[candidateID]; ok {
-				candidates[candidateID] = false
 				continue
 			}
 

--- a/internal/evaluator/weapon_tree.go
+++ b/internal/evaluator/weapon_tree.go
@@ -22,8 +22,10 @@ type WeaponTree struct {
 	db          *sql.DB
 	dataService TreeDataProvider
 	constraints WeaponTreeConstraints
-	// TODO: evaluator should use AllowedItemConflicts this to generate all zero-conflict candidate item sets
+	// all itemIDs which conflict globally with other itemIDs
 	AllowedItemConflicts map[string]map[string]bool
+	// all candidate items for this weapon
+	CandidateItems map[string]bool
 }
 
 func (wt *WeaponTree) AddItemConflicts(itemId string, conflictIDs []string) {
@@ -36,6 +38,10 @@ func (wt *WeaponTree) AddItemConflicts(itemId string, conflictIDs []string) {
 	}
 }
 
+func (wt *WeaponTree) AddCandidateItem(itemID string) {
+	wt.CandidateItems[itemID] = true
+}
+
 func ConstructWeaponTree(id string, data TreeDataProvider) (*WeaponTree, error) {
 	weaponTree := &WeaponTree{
 		dataService: data,
@@ -43,6 +49,7 @@ func ConstructWeaponTree(id string, data TreeDataProvider) (*WeaponTree, error) 
 			ignoredSlotNames: map[string]bool{"Scope": true, "Ubgl": true},
 		},
 		AllowedItemConflicts: map[string]map[string]bool{},
+		CandidateItems:       map[string]bool{},
 	}
 
 	w, err := data.GetWeaponById(id)

--- a/internal/evaluator/weapon_tree.go
+++ b/internal/evaluator/weapon_tree.go
@@ -18,15 +18,22 @@ type WeaponTreeConstraints struct {
 }
 
 type WeaponTree struct {
-	Item                 *Item
-	db                   *sql.DB
-	dataService          TreeDataProvider
-	constraints          WeaponTreeConstraints
-	allowedItemConflicts map[string]string
+	Item        *Item
+	db          *sql.DB
+	dataService TreeDataProvider
+	constraints WeaponTreeConstraints
+	// TODO: evaluator should use AllowedItemConflicts this to generate all zero-conflict candidate item sets
+	AllowedItemConflicts map[string]map[string]bool
 }
 
-func (wt *WeaponTree) AddItemConflicts(itemId string, conflictId string) {
-	wt.allowedItemConflicts[itemId] = conflictId
+func (wt *WeaponTree) AddItemConflicts(itemId string, conflictIDs []string) {
+	if _, ok := wt.AllowedItemConflicts[itemId]; !ok {
+		wt.AllowedItemConflicts[itemId] = map[string]bool{}
+	}
+
+	for _, conflictId := range conflictIDs {
+		wt.AllowedItemConflicts[itemId][conflictId] = true
+	}
 }
 
 func ConstructWeaponTree(id string, data TreeDataProvider) (*WeaponTree, error) {
@@ -35,6 +42,7 @@ func ConstructWeaponTree(id string, data TreeDataProvider) (*WeaponTree, error) 
 		constraints: WeaponTreeConstraints{
 			ignoredSlotNames: map[string]bool{"Scope": true, "Ubgl": true},
 		},
+		AllowedItemConflicts: map[string]map[string]bool{},
 	}
 
 	w, err := data.GetWeaponById(id)

--- a/internal/evaluator/weapon_tree.go
+++ b/internal/evaluator/weapon_tree.go
@@ -78,3 +78,39 @@ func ConstructWeaponTree(id string, data TreeDataProvider) (*WeaponTree, error) 
 
 	return weaponTree, nil
 }
+
+func GenerateNonConflictingCandidateSets(candidates map[string]bool, conflicts map[string]map[string]bool) [][]string {
+	candidateIDSets := make([][]string, 0)
+	resolved := map[string]bool{}
+
+	conflictCount := len(conflicts)
+	for conflictCount > 0 {
+		candidateIDSet := make([]string, 0)
+		bans := map[string]bool{}
+		for candidateID, _ := range candidates {
+			if _, ok := resolved[candidateID]; ok {
+				candidates[candidateID] = false
+				continue
+			}
+
+			if _, ok := bans[candidateID]; ok {
+				continue
+			}
+
+			if _, ok := conflicts[candidateID]; ok {
+				resolved[candidateID] = true
+
+				for bannedID, _ := range conflicts[candidateID] {
+					bans[bannedID] = true
+				}
+
+				conflictCount--
+			}
+
+			candidateIDSet = append(candidateIDSet, candidateID)
+		}
+		candidateIDSets = append(candidateIDSets, candidateIDSet)
+	}
+
+	return candidateIDSets
+}

--- a/internal/evaluator/weapon_tree.go
+++ b/internal/evaluator/weapon_tree.go
@@ -18,10 +18,15 @@ type WeaponTreeConstraints struct {
 }
 
 type WeaponTree struct {
-	Item        *Item
-	db          *sql.DB
-	dataService TreeDataProvider
-	constraints WeaponTreeConstraints
+	Item                 *Item
+	db                   *sql.DB
+	dataService          TreeDataProvider
+	constraints          WeaponTreeConstraints
+	allowedItemConflicts map[string]string
+}
+
+func (wt *WeaponTree) AddItemConflicts(itemId string, conflictId string) {
+	wt.allowedItemConflicts[itemId] = conflictId
 }
 
 func ConstructWeaponTree(id string, data TreeDataProvider) (*WeaponTree, error) {

--- a/internal/evaluator/weapon_tree_test.go
+++ b/internal/evaluator/weapon_tree_test.go
@@ -1,0 +1,44 @@
+package evaluator
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestGenerateNonConflictingCandidateSets(t *testing.T) {
+	candidates := map[string]bool{
+		"1": true,
+		"2": true,
+		"3": true,
+		"4": true,
+		"5": true,
+		"6": true,
+	}
+
+	conflicts := map[string]map[string]bool{
+		"1": map[string]bool{"2": true, "3": true},
+		"2": map[string]bool{"1": true, "3": true},
+		"3": map[string]bool{"1": true, "2": true},
+	}
+
+	sets := GenerateNonConflictingCandidateSets(candidates, conflicts)
+	assert.Equal(t, 3, len(sets))
+
+	counts := map[string]int{}
+	for _, set := range sets {
+		for _, id := range set {
+			if _, ok := counts[id]; ok {
+				counts[id]++
+			} else {
+				counts[id] = 1
+			}
+		}
+	}
+
+	assert.Equal(t, 1, counts["1"])
+	assert.Equal(t, 1, counts["2"])
+	assert.Equal(t, 1, counts["3"])
+	assert.Equal(t, 3, counts["4"])
+	assert.Equal(t, 3, counts["5"])
+	assert.Equal(t, 3, counts["6"])
+}

--- a/internal/importers/mods.go
+++ b/internal/importers/mods.go
@@ -105,6 +105,11 @@ func getModsFromTarkovDev(api *tarkovdev.Api) ([]models.WeaponMod, error) {
 			Name:               mod.Name,
 			ErgonomicsModifier: int(mod.ErgonomicsModifier),
 			RecoilModifier:     int(mod.RecoilModifier),
+			ConflictingItems:   make([]string, 0, len(mod.ConflictingItems)),
+		}
+
+		for j := 0; j < len(mod.ConflictingItems); j++ {
+			newMod.ConflictingItems = append(newMod.ConflictingItems, mod.ConflictingItems[j].Id)
 		}
 
 		var slots []models.Slot

--- a/internal/models/conflicting_items.go
+++ b/internal/models/conflicting_items.go
@@ -7,11 +7,29 @@ type ConflictingItem struct {
 	ConflictingItemID string `json:"conflicting_item_id"`
 }
 
-func UpsertConflictingItems(tx *sql.Tx, itemID string, conflictingItemID string) error {
-	query := `INSERT INTO conflicting_items (item_id, conflicting_item_id) values ($1, $2);`
-	_, err := tx.Exec(query, itemID, conflictingItemID)
+func upsertConflictingItem(tx *sql.Tx, itemID string, conflictingItemID string) error {
+	query := `INSERT INTO conflicting_items (
+	   item_id,
+	   conflicting_item_id
+   ) VALUES ($1, $2)
+     ON CONFLICT (item_id, conflicting_item_id) DO NOTHING;`
+	_, err := tx.Exec(
+		query,
+		itemID,
+		conflictingItemID,
+	)
 	if err != nil {
 		return err
+	}
+	return nil
+}
+
+func upsertManyConflictingItems(tx *sql.Tx, itemID string, conflictingItemIDs []string) error {
+	for i := 0; i < len(conflictingItemIDs); i++ {
+		err := upsertConflictingItem(tx, itemID, conflictingItemIDs[i])
+		if err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/internal/models/conflicting_items.go
+++ b/internal/models/conflicting_items.go
@@ -1,0 +1,5 @@
+package models
+
+func UpsertConflictingItems(itemID string, conflictingItemID string) error {
+	return nil
+}

--- a/internal/models/conflicting_items.go
+++ b/internal/models/conflicting_items.go
@@ -1,5 +1,17 @@
 package models
 
-func UpsertConflictingItems(itemID string, conflictingItemID string) error {
+import "database/sql"
+
+type ConflictingItem struct {
+	ItemID            string `json:"item_id"`
+	ConflictingItemID string `json:"conflicting_item_id"`
+}
+
+func UpsertConflictingItems(tx *sql.Tx, itemID string, conflictingItemID string) error {
+	query := `INSERT INTO conflicting_items (item_id, conflicting_item_id) values ($1, $2);`
+	_, err := tx.Exec(query, itemID, conflictingItemID)
+	if err != nil {
+		return err
+	}
 	return nil
 }

--- a/internal/tarkovdev/generated-queries.go
+++ b/internal/tarkovdev/generated-queries.go
@@ -254,12 +254,14 @@ func (v *GetItemPricesResponse) GetItems() []GetItemPricesItemsItem { return v.I
 
 // GetWeaponModsItemsItem includes the requested fields of the GraphQL type Item.
 type GetWeaponModsItemsItem struct {
-	Name               string                           `json:"name"`
-	Id                 string                           `json:"id"`
-	ErgonomicsModifier float64                          `json:"ergonomicsModifier"`
-	RecoilModifier     float64                          `json:"recoilModifier"`
-	Types              []ItemType                       `json:"types"`
-	Properties         GetWeaponModsItemsItemProperties `json:"-"`
+	Name               string                                       `json:"name"`
+	Id                 string                                       `json:"id"`
+	ErgonomicsModifier float64                                      `json:"ergonomicsModifier"`
+	RecoilModifier     float64                                      `json:"recoilModifier"`
+	Types              []ItemType                                   `json:"types"`
+	ConflictingItems   []GetWeaponModsItemsItemConflictingItemsItem `json:"conflictingItems"`
+	Category           GetWeaponModsItemsItemCategory               `json:"category"`
+	Properties         GetWeaponModsItemsItemProperties             `json:"-"`
 }
 
 // GetName returns GetWeaponModsItemsItem.Name, and is useful for accessing the field via an interface.
@@ -276,6 +278,14 @@ func (v *GetWeaponModsItemsItem) GetRecoilModifier() float64 { return v.RecoilMo
 
 // GetTypes returns GetWeaponModsItemsItem.Types, and is useful for accessing the field via an interface.
 func (v *GetWeaponModsItemsItem) GetTypes() []ItemType { return v.Types }
+
+// GetConflictingItems returns GetWeaponModsItemsItem.ConflictingItems, and is useful for accessing the field via an interface.
+func (v *GetWeaponModsItemsItem) GetConflictingItems() []GetWeaponModsItemsItemConflictingItemsItem {
+	return v.ConflictingItems
+}
+
+// GetCategory returns GetWeaponModsItemsItem.Category, and is useful for accessing the field via an interface.
+func (v *GetWeaponModsItemsItem) GetCategory() GetWeaponModsItemsItemCategory { return v.Category }
 
 // GetProperties returns GetWeaponModsItemsItem.Properties, and is useful for accessing the field via an interface.
 func (v *GetWeaponModsItemsItem) GetProperties() GetWeaponModsItemsItemProperties {
@@ -326,6 +336,10 @@ type __premarshalGetWeaponModsItemsItem struct {
 
 	Types []ItemType `json:"types"`
 
+	ConflictingItems []GetWeaponModsItemsItemConflictingItemsItem `json:"conflictingItems"`
+
+	Category GetWeaponModsItemsItemCategory `json:"category"`
+
 	Properties json.RawMessage `json:"properties"`
 }
 
@@ -345,6 +359,8 @@ func (v *GetWeaponModsItemsItem) __premarshalJSON() (*__premarshalGetWeaponModsI
 	retval.ErgonomicsModifier = v.ErgonomicsModifier
 	retval.RecoilModifier = v.RecoilModifier
 	retval.Types = v.Types
+	retval.ConflictingItems = v.ConflictingItems
+	retval.Category = v.Category
 	{
 
 		dst := &retval.Properties
@@ -359,6 +375,30 @@ func (v *GetWeaponModsItemsItem) __premarshalJSON() (*__premarshalGetWeaponModsI
 	}
 	return &retval, nil
 }
+
+// GetWeaponModsItemsItemCategory includes the requested fields of the GraphQL type ItemCategory.
+type GetWeaponModsItemsItemCategory struct {
+	Name string `json:"name"`
+	Id   string `json:"id"`
+}
+
+// GetName returns GetWeaponModsItemsItemCategory.Name, and is useful for accessing the field via an interface.
+func (v *GetWeaponModsItemsItemCategory) GetName() string { return v.Name }
+
+// GetId returns GetWeaponModsItemsItemCategory.Id, and is useful for accessing the field via an interface.
+func (v *GetWeaponModsItemsItemCategory) GetId() string { return v.Id }
+
+// GetWeaponModsItemsItemConflictingItemsItem includes the requested fields of the GraphQL type Item.
+type GetWeaponModsItemsItemConflictingItemsItem struct {
+	Id   string `json:"id"`
+	Name string `json:"name"`
+}
+
+// GetId returns GetWeaponModsItemsItemConflictingItemsItem.Id, and is useful for accessing the field via an interface.
+func (v *GetWeaponModsItemsItemConflictingItemsItem) GetId() string { return v.Id }
+
+// GetName returns GetWeaponModsItemsItemConflictingItemsItem.Name, and is useful for accessing the field via an interface.
+func (v *GetWeaponModsItemsItemConflictingItemsItem) GetName() string { return v.Name }
 
 // GetWeaponModsItemsItemProperties includes the requested fields of the GraphQL interface ItemProperties.
 //
@@ -1315,13 +1355,14 @@ func (v *GetWeaponModsResponse) GetItems() []GetWeaponModsItemsItem { return v.I
 
 // GetWeaponsItemsItem includes the requested fields of the GraphQL type Item.
 type GetWeaponsItemsItem struct {
-	Typename           string                        `json:"__typename"`
-	Name               string                        `json:"name"`
-	Id                 string                        `json:"id"`
-	ErgonomicsModifier float64                       `json:"ergonomicsModifier"`
-	RecoilModifier     float64                       `json:"recoilModifier"`
-	Types              []ItemType                    `json:"types"`
-	Properties         GetWeaponsItemsItemProperties `json:"-"`
+	Typename           string                                    `json:"__typename"`
+	Name               string                                    `json:"name"`
+	Id                 string                                    `json:"id"`
+	ErgonomicsModifier float64                                   `json:"ergonomicsModifier"`
+	RecoilModifier     float64                                   `json:"recoilModifier"`
+	Types              []ItemType                                `json:"types"`
+	ConflictingItems   []GetWeaponsItemsItemConflictingItemsItem `json:"conflictingItems"`
+	Properties         GetWeaponsItemsItemProperties             `json:"-"`
 }
 
 // GetTypename returns GetWeaponsItemsItem.Typename, and is useful for accessing the field via an interface.
@@ -1341,6 +1382,11 @@ func (v *GetWeaponsItemsItem) GetRecoilModifier() float64 { return v.RecoilModif
 
 // GetTypes returns GetWeaponsItemsItem.Types, and is useful for accessing the field via an interface.
 func (v *GetWeaponsItemsItem) GetTypes() []ItemType { return v.Types }
+
+// GetConflictingItems returns GetWeaponsItemsItem.ConflictingItems, and is useful for accessing the field via an interface.
+func (v *GetWeaponsItemsItem) GetConflictingItems() []GetWeaponsItemsItemConflictingItemsItem {
+	return v.ConflictingItems
+}
 
 // GetProperties returns GetWeaponsItemsItem.Properties, and is useful for accessing the field via an interface.
 func (v *GetWeaponsItemsItem) GetProperties() GetWeaponsItemsItemProperties { return v.Properties }
@@ -1391,6 +1437,8 @@ type __premarshalGetWeaponsItemsItem struct {
 
 	Types []ItemType `json:"types"`
 
+	ConflictingItems []GetWeaponsItemsItemConflictingItemsItem `json:"conflictingItems"`
+
 	Properties json.RawMessage `json:"properties"`
 }
 
@@ -1411,6 +1459,7 @@ func (v *GetWeaponsItemsItem) __premarshalJSON() (*__premarshalGetWeaponsItemsIt
 	retval.ErgonomicsModifier = v.ErgonomicsModifier
 	retval.RecoilModifier = v.RecoilModifier
 	retval.Types = v.Types
+	retval.ConflictingItems = v.ConflictingItems
 	{
 
 		dst := &retval.Properties
@@ -1425,6 +1474,18 @@ func (v *GetWeaponsItemsItem) __premarshalJSON() (*__premarshalGetWeaponsItemsIt
 	}
 	return &retval, nil
 }
+
+// GetWeaponsItemsItemConflictingItemsItem includes the requested fields of the GraphQL type Item.
+type GetWeaponsItemsItemConflictingItemsItem struct {
+	Id   string `json:"id"`
+	Name string `json:"name"`
+}
+
+// GetId returns GetWeaponsItemsItemConflictingItemsItem.Id, and is useful for accessing the field via an interface.
+func (v *GetWeaponsItemsItemConflictingItemsItem) GetId() string { return v.Id }
+
+// GetName returns GetWeaponsItemsItemConflictingItemsItem.Name, and is useful for accessing the field via an interface.
+func (v *GetWeaponsItemsItemConflictingItemsItem) GetName() string { return v.Name }
 
 // GetWeaponsItemsItemProperties includes the requested fields of the GraphQL interface ItemProperties.
 //
@@ -2254,6 +2315,14 @@ query GetWeaponMods {
 		ergonomicsModifier
 		recoilModifier
 		types
+		conflictingItems {
+			id
+			name
+		}
+		category {
+			name
+			id
+		}
 		properties {
 			__typename
 			... on ItemPropertiesWeaponMod {
@@ -2353,6 +2422,10 @@ query GetWeapons {
 		ergonomicsModifier
 		recoilModifier
 		types
+		conflictingItems {
+			id
+			name
+		}
 		properties {
 			__typename
 			... on ItemPropertiesWeapon {

--- a/internal/tarkovdev/schemas/queries.graphql
+++ b/internal/tarkovdev/schemas/queries.graphql
@@ -5,6 +5,14 @@ query GetWeaponMods {
     ergonomicsModifier
     recoilModifier
     types
+    conflictingItems {
+        id
+        name
+    }
+    category {
+      name
+      id
+    }
     properties {
       ... on ItemPropertiesWeaponMod {
         __typename
@@ -78,6 +86,10 @@ query GetWeapons {
     ergonomicsModifier
     recoilModifier
     types
+    conflictingItems {
+        id
+        name
+    }
     properties {
       ... on ItemPropertiesWeapon {
         __typename

--- a/migrations/20241008232129_conflicting_items.go
+++ b/migrations/20241008232129_conflicting_items.go
@@ -1,0 +1,37 @@
+package migrations
+
+import (
+	"context"
+	"database/sql"
+	"github.com/pressly/goose/v3"
+	"github.com/rs/zerolog/log"
+)
+
+func init() {
+	goose.AddMigrationContext(upConflictingItems, downConflictingItems)
+}
+
+func upConflictingItems(ctx context.Context, tx *sql.Tx) error {
+	_, err := tx.ExecContext(ctx, `
+	create table conflicting_items
+	    (
+	        item_id varchar,
+	        conflicting_item_id varchar,
+ 			unique (item_id, conflicting_item_id)
+	    );`)
+	if err != nil {
+		_ = tx.Rollback()
+		log.Fatal().Err(err).Msg("failed to create conflicting_items table")
+	}
+	return nil
+}
+
+func downConflictingItems(ctx context.Context, tx *sql.Tx) error {
+	_, err := tx.ExecContext(ctx, `drop table conflicting_items;`)
+	if err != nil {
+		_ = tx.Rollback()
+		log.Fatal().Err(err).Msg("failed to drop conflicting_items")
+	}
+
+	return nil
+}

--- a/scripts/install-go-deps.sh
+++ b/scripts/install-go-deps.sh
@@ -1,4 +1,2 @@
-#!/bin/bash
-
 go install github.com/pressly/goose/v3/cmd/goose@latest
 go install github.com/go-task/task/v3/cmd/task@latest


### PR DESCRIPTION
Item conflicts should now be taken into account, preventing weirdness like M4s with multiple barrels... 
- when a candidate tree has 1 or more conflicting items, we now generate all possible conflict-free sets of candidate items prior to build evaluation.
- evaluator is now passed a candidate item slice which serves as a whitelist for evaluation.
- once all candidate item sets have been evaluated the one with the highest (for ergo)/lowest (for recoil) sum is chosen as the optimum_build for that weapon & trader level constraints.
